### PR TITLE
Make the search case-insensitive

### DIFF
--- a/DessertIsland/DessertIsland/Views/RecipeListView.swift
+++ b/DessertIsland/DessertIsland/Views/RecipeListView.swift
@@ -13,7 +13,7 @@ struct RecipeListView: View {
     
     var filteredRecipes: [RecipeListEntry] {
         recipeList.recipes.filter { recipe in
-            (search.isEmpty || recipe.strMeal.contains(search))
+            (search.isEmpty || recipe.strMeal.lowercased().contains(search.lowercased()))
         }
     }
     


### PR DESCRIPTION
The search feature was originally case-sensitive. It is now case-insensitive to make searching recipes a bit more straightforward